### PR TITLE
Bug: Docker default workdir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,5 +30,6 @@ RUN dotnet vstest test/*/bin/Release/*/*Tests.dll
 RUN dotnet publish src/App -c Release -o /app/out --no-restore
 
 FROM microsoft/dotnet:2.2-runtime
+WORKDIR /app
 COPY --from=build-env /app/out .
 ENTRYPOINT ["dotnet", "App.dll"]


### PR DESCRIPTION
Following Issue #12 - changing the workdir to the folder created at the start of the dockerfile /app.